### PR TITLE
Content-Security-Policy: allow unsafe-inline

### DIFF
--- a/calvados.go
+++ b/calvados.go
@@ -408,7 +408,7 @@ func (calva *Calvados) ReplyMardown(c *gin.Context, httpStatus int, resourcePath
 // Adds the security HTTP headers to all HTTP responses
 func (calva *Calvados) MWAddSecurityHTTPHeaders(c *gin.Context) {
 	// add CSP header to HTTP responses
-	c.Header("Content-Security-Policy", "script-src 'self'")
+	c.Header("Content-Security-Policy", "script-src 'self' 'unsafe-inline'")
 	// add X-Frame-Options header to HTTP responses
 	c.Header("X-Frame-Options", "DENY")
 	// add X-XSS-Protection header to HTTP responses


### PR DESCRIPTION
Adds `unsafe-inline` to `Content-Security-Policy` header. 
Otherwise, it's not possible to declare `<script>` blocks in the HTML, it's a little too strict... 😅